### PR TITLE
Add requirements.txt with pinned package versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+beautifulsoup4 ~= 4.9
+numpy ~= 1.20
+pandas ~= 1.2
+requests ~= 2.25


### PR DESCRIPTION
Usually it's a good idea to pin package versions so not to depend on upstream changes during development. It also specifies in a single place which packages are required for the project to work.

[pip docs on the topic](https://pip.pypa.io/en/latest/reference/pip_install/#example-requirements-file)
